### PR TITLE
NP-309: Add modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ ContentfulConverter.configure do |config|
 end
 ```
 
+**Modifiers**
+
+Optional parameter to overwrite existing rules. Must be a hash.
+
+```ruby
+ContentfulConverter.convert('<h3>hello world</h3>', { force_header_size: "1" })
+
+# OUTPUT
+{
+  :nodeType=>"document",
+  :data=>{},
+  :content=>[
+    {
+      :nodeType=>"heading-1",
+      :data=>{},
+      :content=>[
+        {
+          :marks=>[],
+          :value=>"hello world",
+          :nodeType=>"text",
+          :data=>{}
+        }
+      ]
+    }
+  ]
+}
+```
+
 **`<a>`**
 
 * HTML hyperlinks with full URL e.g: (`<a href="https://google.com"></a>`), will be converted into URL hyperlinks

--- a/lib/contentful_converter.rb
+++ b/lib/contentful_converter.rb
@@ -3,7 +3,12 @@
 require 'contentful_converter/converter'
 
 module ContentfulConverter
-  def self.convert(html)
+  def self.convert(html, modifiers = {})
+    @@modifiers = modifiers
     Converter.convert(html)
+  end
+
+  def self.modifiers
+    @@modifiers
   end
 end

--- a/lib/contentful_converter/nodes/header.rb
+++ b/lib/contentful_converter/nodes/header.rb
@@ -16,7 +16,7 @@ module ContentfulConverter
       end
 
       def header_size
-        nokogiri_node.name.split('h').last
+        ContentfulConverter.modifiers[:force_header_size] || nokogiri_node.name.split('h').last
       end
     end
   end

--- a/spec/contentful_converter_spec.rb
+++ b/spec/contentful_converter_spec.rb
@@ -6,9 +6,10 @@ require 'contentful_converter'
 describe ContentfulConverter do
   let(:converter) { ContentfulConverter::Converter }
   let(:html) { '<html><body><h1>hello world</h1><p>hi</p></body></html>' }
+  let(:modifier) { { force_header_size: "3" } }
 
   before do
-    allow(converter).to receive(:convert).with(html) { {} }
+    allow(converter).to receive(:convert).with(html)
   end
 
   describe '.convert' do
@@ -19,6 +20,11 @@ describe ContentfulConverter do
         .and_return(Hash)
 
       described_class.convert(html)
+    end
+
+    it 'sets the modifiers as a class variable' do
+      described_class.convert(html, modifier)
+      expect(described_class.modifiers).to eq(modifier)
     end
   end
 end

--- a/spec/lib/node_builder_spec.rb
+++ b/spec/lib/node_builder_spec.rb
@@ -18,12 +18,30 @@ describe ContentfulConverter::NodeBuilder do
       end
 
       context 'when we pass in header nokogiri nodes' do
-        it 'instantiates a Header rich_text node' do
-          %w[h1 h2 h3 h4 h5 h6].each do |v|
-            allow(nokogiri_node).to receive(:name) { v }
+        context 'when no modifier is passed in' do
+          it 'instantiates a Header rich_text node' do
+            %w[h1 h2 h3 h4 h5 h6].each do |v|
+              allow(nokogiri_node).to receive(:name) { v }
 
-            expect(described_class.build(nokogiri_node))
-              .to be_an_instance_of(ContentfulConverter::Nodes::Header)
+              expect(described_class.build(nokogiri_node))
+                .to be_an_instance_of(ContentfulConverter::Nodes::Header)
+            end
+          end
+        end
+
+        context 'when a force_header_size modifier is passed in' do
+          let(:heading_size) { "3" }
+          before do
+            allow(ContentfulConverter).to receive(:modifiers).and_return({ force_header_size: heading_size })
+          end
+
+          it "instantiates a Header rich_text node with the correct header size" do
+            %w[h1 h2 h3 h4 h5 h6].each do |v|
+              allow(nokogiri_node).to receive(:name) { v }
+
+              expect(described_class.build(nokogiri_node).node_type)
+                .to eq("heading-#{heading_size}")
+            end
           end
         end
       end


### PR DESCRIPTION
Episerver saves it's rich text content in html markup whereas Contentful requires it's own schema in order to render rich text.

To achieve this translation, every time we encounter rich text content when migrating from Episerver, we send it through this gem for conversion.

When migrating certain content types from Episerver, a need has arisen to override the current functionality and force our own logic (for example, for Callouts, regardless of what heading size was in Contentful, we always want to return an h3).

This PR allows the `.convert` method to be called with an optional modifications hash that can then be accessed for further logic within the individual conversions.