### PR TITLE
Return path from ca links

### DIFF
--- a/lib/contentful_converter/nodes/hyperlink.rb
+++ b/lib/contentful_converter/nodes/hyperlink.rb
@@ -40,6 +40,16 @@ module ContentfulConverter
         }
       end
 
+      def hyperlink_option
+        link = parsed_link.host == 'citizensadvice.org.uk' ? link_path : parsed_link
+
+        { data: { uri: link.to_s } }
+      end
+
+      def link_path
+        parsed_link.path
+      end
+
       def uri_scheme?
         parsed_link.scheme
       end

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.1.27'
+  VERSION = '0.0.1.28'
 end

--- a/spec/features/html_to_rich_text_test.rb
+++ b/spec/features/html_to_rich_text_test.rb
@@ -104,40 +104,80 @@ describe ContentfulConverter::Converter do
 
       context 'When we have a link' do
         context 'When the link has protocol e.g http(s)' do
-          let(:html) do
-            '<html><body><a href="https://google.com">click me</a></body></html>'
-          end
-          let(:expected_hash) do
-            {
-              nodeType: 'document',
-              data: {},
-              content: [
-                {
-                  nodeType: 'paragraph',
-                  data: {},
-                  content: [
-                    {
-                      nodeType: 'hyperlink',
-                      data: {
-                        uri: 'https://google.com'
-                      },
-                      content: [
-                        {
-                          marks: [],
-                          value: 'click me',
-                          nodeType: 'text',
-                          data: {}
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+          context 'When the host is citizensadvice.org.uk' do
+            let(:html) do
+              '<html><body><a href="https://citizensadvice.org.uk/mypage">click me</a></body></html>'
+            end
+            let(:expected_hash) do
+              {
+                nodeType: 'document',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    data: {},
+                    content: [
+                      {
+                        nodeType: 'hyperlink',
+                        data: {
+                          uri: '/mypage'
+                        },
+                        content: [
+                          {
+                            marks: [],
+                            value: 'click me',
+                            nodeType: 'text',
+                            data: {}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
+
+            it 'creates a normal hyperlink structure' do
+              expect(described_class.convert(html)).to eq expected_hash
+            end
           end
 
-          it 'creates a normal hyperlink structure' do
-            expect(described_class.convert(html)).to eq expected_hash
+          context 'When the host is not citizensadvice.org.uk' do
+            let(:html) do
+              '<html><body><a href="https://google.com">click me</a></body></html>'
+            end
+            let(:expected_hash) do
+              {
+                nodeType: 'document',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    data: {},
+                    content: [
+                      {
+                        nodeType: 'hyperlink',
+                        data: {
+                          uri: 'https://google.com'
+                        },
+                        content: [
+                          {
+                            marks: [],
+                            value: 'click me',
+                            nodeType: 'text',
+                            data: {}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
+
+            it 'creates a normal hyperlink structure' do
+              expect(described_class.convert(html)).to eq expected_hash
+            end
           end
         end
 


### PR DESCRIPTION
Moving forwards we want to have relative links as far as possible within Contentful. This PR identifies links that begin 'citizensadvice.org.uk' and returns only the path.

NOTE
We prepend http://www.citizensadvice.org.uk to the beginning of non migrated links in the migration scripts, but we need this to stay there until this point as we need to differentiate between migrated and non migrated pages. By stripping back out here, it still allows us to make that distinction and handle them appropriately.