### PR TITLE
chore: Migrate inline embedded content

### DIFF
--- a/lib/contentful_converter/nodes/embed.rb
+++ b/lib/contentful_converter/nodes/embed.rb
@@ -7,7 +7,8 @@ module ContentfulConverter
     class Embed < Hyperlink
       EMBED_VALUES = {
         asset: 'embedded-asset-block',
-        entry: 'embedded-entry-block'
+        entry: 'embedded-entry-block',
+        inline: 'embedded-entry-inline'
       }.freeze
 
       def needs_p_wrapping?
@@ -21,7 +22,11 @@ module ContentfulConverter
       end
 
       def options
-        hyperlink_entry_option(type_value.to_s.capitalize)
+        if type_value == "inline"
+          hyperlink_entry_option("Entry")
+        else
+          hyperlink_entry_option(type_value.to_s.capitalize)
+        end
       end
 
       def type_value

--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -57,6 +57,8 @@ module ContentfulConverter
 
       def normalize_embeds(nokogiri_fragment)
         find_nodes(nokogiri_fragment, 'p embed').each do |embed_node|
+          next if embed_node.to_s.include?("inline")
+
           embed_node.parent.add_next_sibling(embed_node)
         end
       end

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.1.29'
+  VERSION = '0.0.1.30'
 end

--- a/spec/features/html_to_rich_text_spec.rb
+++ b/spec/features/html_to_rich_text_spec.rb
@@ -383,6 +383,35 @@ describe ContentfulConverter::Converter do
             end
           end
 
+          context 'when it is an inline entry' do
+            let(:html) { '<embed src="2vtrc4TqIHNjolX299pik7" type="inline"/>' }
+            let(:expected_hash) do
+              {
+                nodeType: 'document',
+                data: {},
+                content: [
+                  {
+                    data: {
+                      target: {
+                        sys: {
+                          id: '2vtrc4TqIHNjolX299pik7',
+                          type: 'Link',
+                          linkType: 'Entry'
+                        }
+                      }
+                    },
+                    content: [],
+                    nodeType: 'embedded-entry-inline'
+                  }
+                ]
+              }
+            end
+
+            it 'creates an embedded entry block with the src as an ID' do
+              expect(described_class.convert(html)).to eq expected_hash
+            end
+          end
+
           context 'when it is an asset' do
             let(:html) { '<embed src="2vtrc4TqIHNjolX299pik7" type="asset"/>' }
             let(:expected_hash) do


### PR DESCRIPTION
Whilst working on NP-1735 (migrating anchor links) it became apparent
that we weren't handling inline embedded entries properly during the
conversion stage, so it was causing validation issues.  Essentially we
need to keep inline embedded entries within the paragraph they are in to
not only maintain the original order, but also to pass the Contentful
validation checks as they're expecting inline entries to be within a
paragraph nodetype.

I've also renamed the feature spec as realised this wasn't being
automatically picked up/run by Rspec because the naming convention was
wrong.