### PR TITLE
Stop creating entries for internal links

### DIFF
--- a/lib/contentful_converter/nodes/hyperlink.rb
+++ b/lib/contentful_converter/nodes/hyperlink.rb
@@ -6,9 +6,12 @@ require 'uri'
 module ContentfulConverter
   module Nodes
     class Hyperlink < Base
+      SECTIONS = %w[family immigration debt-and-money law-and-courts consumer benefits health housing work about-us]
       private
 
       def type
+        return 'hyperlink' if parsed_link.to_s.empty?
+        return 'hyperlink' if internal_link?
         return 'asset-hyperlink' if !uri_scheme? && uri_extension?
         return 'entry-hyperlink' if !uri_scheme? && !parsed_link.to_s.include?("#")
 
@@ -16,6 +19,8 @@ module ContentfulConverter
       end
 
       def options
+        return hyperlink_option if parsed_link.to_s.empty?
+        return hyperlink_option if internal_link?
         return hyperlink_entry_option('Asset') if !uri_scheme? && uri_extension?
         return hyperlink_entry_option('Entry') if !uri_scheme? && !parsed_link.to_s.include?("#")
 
@@ -64,6 +69,17 @@ module ContentfulConverter
 
       def link_value
         nokogiri_node[:href]
+      end
+
+      def internal_link?
+        return if parsed_link.path.nil?
+
+        section = parsed_link.to_s.delete_prefix("https://www.citizensadvice.org.uk/")
+        section = section.delete_prefix("/")
+        section = section.delete_prefix("advisernet/")
+        section = section.split("/").compact.first
+
+        SECTIONS.include?(section) || section == "scotland" || section == "wales"
       end
     end
   end

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.1.30'
+  VERSION = '0.0.1.31'
 end

--- a/spec/features/html_to_rich_text_spec.rb
+++ b/spec/features/html_to_rich_text_spec.rb
@@ -182,6 +182,44 @@ describe ContentfulConverter::Converter do
         end
 
         context 'when the link does not have a protocol' do
+          context 'when an internal link' do
+            let(:html) do
+              '<html><body><a href="/advisernet/law-and-courts/legal-aid/what-is-civil-legal-aid/">click me</a></body></html>'
+            end
+            let(:expected_hash) do
+              {
+                nodeType: "document",
+                data: {},
+                content: [
+                  {
+                    nodeType: "paragraph",
+                    data: {},
+                    content: [
+                      {
+                        data: {
+                          uri: "/advisernet/law-and-courts/legal-aid/what-is-civil-legal-aid/"
+                        },
+                        nodeType: "hyperlink",
+                        content: [
+                          {
+                            value: "click me",
+                            marks: [],
+                            nodeType: "text",
+                            data: {}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
+
+            it "creates a hyperlink" do
+              expect(described_class.convert(html)).to eq expected_hash
+            end
+          end
+
           context 'when the link does not contain a hash' do
             let(:html) do
               '<html><body><a href="12398sadkcw">hyperlink entry</a></body></html>'
@@ -315,30 +353,24 @@ describe ContentfulConverter::Converter do
           end
           let(:expected_hash) do
             {
-              nodeType: 'document',
+              nodeType: "document",
               data: {},
               content: [
                 {
-                  nodeType: 'paragraph',
+                  nodeType: "paragraph",
                   data: {},
                   content: [
                     {
-                      nodeType: 'entry-hyperlink',
                       data: {
-                        target: {
-                          sys: {
-                            id: "",
-                            type: 'Link',
-                            linkType: 'Entry'
-                          }
-                        }
+                        uri: ""
                       },
+                      nodeType: "hyperlink",
                       content: [
                         {
-                          data: {},
+                          value: "click",
                           marks: [],
-                          value: 'click',
-                          nodeType: 'text'
+                          nodeType: "text",
+                          data: {}
                         }
                       ]
                     }
@@ -348,7 +380,7 @@ describe ContentfulConverter::Converter do
             }
           end
 
-          it 'creates an entry hyperlink with nil ID' do
+          it 'creates a hyperlink with an empty uri' do
             expect(described_class.convert(html)).to eq expected_hash
           end
         end


### PR DESCRIPTION
One of the biggest issues we have during the migration is when trying to
publish content and getting the error "linked entry is missing or
inaccessible".  When we hit the Contentful converter it would create an
entry link, rather than just a plain hyperlink.  This means when we're trying
to publish a page Contentful is looking for an entry which doesn't
actually exist, and prevents us from publishing.

We can also end up with empty links and this too was creating an
entry-link with no ID.  I think it would be better to just leave these
as hyperlinks to avoid Contentful looking for an entry without an ID.