### PR TITLE
Stop adding a space to ul items

### DIFF
--- a/lib/contentful_converter/nodes/hyperlink.rb
+++ b/lib/contentful_converter/nodes/hyperlink.rb
@@ -27,10 +27,6 @@ module ContentfulConverter
         hyperlink_option
       end
 
-      def hyperlink_option
-        { data: { uri: parsed_link.to_s } }
-      end
-
       def hyperlink_entry_option(type)
         {
           data: {

--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -77,20 +77,11 @@ module ContentfulConverter
         return if node.children.count == 1 && node.children.first.name == 'p'
 
         find_nodes(node, 'p').each { |p_node| p_node.swap(p_node.children) }
-        node_children = append_space_to_text_nodes(node.children.remove, node)
+        node_children = node.children.remove
 
         node.add_child('<p>')
         node.at_css('p').children = node_children
         merge_text_nodes(node)
-      end
-
-      def append_space_to_text_nodes(children, node)
-        children.each do |child|
-          next if child.text.chomp.empty? || child.text.end_with?(' ')
-
-          child.content = create_text_node("#{child.text} ", node)
-        end
-        children
       end
 
       def find_nodes(html_node, element)

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.1.31'
+  VERSION = '0.0.1.32'
 end

--- a/spec/features/html_to_rich_text_spec.rb
+++ b/spec/features/html_to_rich_text_spec.rb
@@ -577,7 +577,7 @@ describe ContentfulConverter::Converter do
                         content: [
                           {
                             marks: [],
-                            value: 'list text ',
+                            value: 'list text',
                             nodeType: 'text',
                             data: {}
                           }

--- a/spec/lib/nokogiri_builder_spec.rb
+++ b/spec/lib/nokogiri_builder_spec.rb
@@ -28,9 +28,9 @@ describe ContentfulConverter::NokogiriBuilder do
 
       context 'when the list has multiple p children' do
         let(:html) { '<ol><li><p>testing</p><p>test2</p></li></ol>' }
-        let(:expected_html) { "<ol><li><p>testing test2 </p></li></ol>" }
+        let(:expected_html) { "<ol><li><p>testingtest2</p></li></ol>" }
 
-        it 'wraps the children in a single p element and adds spaces' do
+        it 'wraps the children in a single p element' do
           result = described_class.build(html)
           expect(result.to_html).to eq(expected_html)
         end
@@ -38,9 +38,9 @@ describe ContentfulConverter::NokogiriBuilder do
 
       context 'when the list has multiple mixed children' do
         let(:html) { '<ol><li><p>test</p><u>test2</u><i>test2</i></li></ol>' }
-        let(:expected_html) { "<ol><li><p>test <u>test2 </u><i>test2 </i></p></li></ol>" }
+        let(:expected_html) { "<ol><li><p>test<u>test2</u><i>test2</i></p></li></ol>" }
 
-        it 'wraps the children in a single p element and adds spaces' do
+        it 'wraps the children in a single p element' do
           result = described_class.build(html)
           expect(result.to_html).to eq(expected_html)
         end


### PR DESCRIPTION
During the Family section sense check a number of issues were logged in
regards to extra spaces being added to some links/sentences.  It turns
out that we have been adding an extra space when creating ul list items
which resulted in things like "savings disregard .".  I've removed the
step that adds the extra space, done a migration to QA with this change
and Claire has been through the content fix sheet to check them all.
According to her checks this has resolved all these issues.

It wasn't clear why we were adding this space, and through the checks
that both Claire and I have done we haven't come across any issues thus
far that would indicate that this change is causing any knock on
effects, but this is something that we can keep an eye on and review
again if needs be