### PR TITLE
fix/hyperlinks incorrectly converted to entry

### DIFF
--- a/lib/contentful_converter/nodes/hyperlink.rb
+++ b/lib/contentful_converter/nodes/hyperlink.rb
@@ -6,7 +6,7 @@ require 'uri'
 module ContentfulConverter
   module Nodes
     class Hyperlink < Base
-      SECTIONS = %w[family immigration debt-and-money law-and-courts consumer benefits health housing work about-us]
+      SECTIONS = %w[family immigration debt-and-money law-and-courts consumer benefits health housing work about-us resources]
       private
 
       def type


### PR DESCRIPTION
Whilst running the migration scripts against Debt & Money there were issues where entries weren't publishing in Contentful as it thought a link should have been an entry, rather than a hyperlink.

The issue was that there were links to `/advisernet/resources/*` which wasn't in our list of sections to determine if it's an internal link or not, so they were incorrectly being transformed into entries.  I've re-imported an advice collection with this code change and can confirm the link is now a hyperlink