### PR TITLE
fix/ intranet links issue

### DIFF
--- a/lib/contentful_converter/nodes/hyperlink.rb
+++ b/lib/contentful_converter/nodes/hyperlink.rb
@@ -6,7 +6,7 @@ require 'uri'
 module ContentfulConverter
   module Nodes
     class Hyperlink < Base
-      SECTIONS = %w[family immigration debt-and-money law-and-courts consumer benefits health housing work about-us resources]
+      SECTIONS = %w[family immigration debt-and-money law-and-courts consumer benefits health housing work about-us resources intranet]
       private
 
       def type

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.1.32'
+  VERSION = '0.0.1.33'
 end


### PR DESCRIPTION
There are issues where entries which included links to `/intranet/*`  weren't publishing in Contentful as it thought a link should have been an entry, rather than a hyperlink.

The issue was that the `/intranet/` wasn't in our list of sections to determine if it's an internal link or not, so they were incorrectly being transformed into entries. I've re-imported an entry with a link to the intranet to confirm the fix works.  We'd not seen intranet links in previous sections we'd migrated, so that's why it was missed