### PR TITLE
fix: append rows in tables so their order is maintained

### DIFF
--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -85,7 +85,7 @@ module ContentfulConverter
         trs = find_nodes(table_node, "#{container} tr")
         containers = find_nodes(table_node, container)
         containers.remove
-        table_node.prepend_child(trs)
+        table_node.add_child(trs)
       end
 
 

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/spec/features/tables_spec.rb
+++ b/spec/features/tables_spec.rb
@@ -137,7 +137,7 @@ describe ContentfulConverter::Converter do
 
 
     context 'when there are two tables' do
-      let(:html) { '<table><tbody><tr><td><p>Content in a table data cell.</p></td></tr></tbody></table><p>Another table:</p><table><tbody><tr><td><p>Content in a table data cell.</p></td></tr></tbody></table>' }
+      let(:html) { '<table><tbody><tr><td><p>Content in a table data cell first row.</p></td></tr></tbody></table><p>Another table:</p><table><tbody><tr><td><p>Content in a table data cell second row.</p></td></tr></tbody></table>' }
       let(:expected_hash) do
         {:nodeType=>"document",
         :data=>{},
@@ -154,7 +154,7 @@ describe ContentfulConverter::Converter do
                   [{:nodeType=>"paragraph",
                     :data=>{},
                     :content=>
-                     [{:value=>"Content in a table data cell.",
+                     [{:value=>"Content in a table data cell first row.",
                        :marks=>[],
                        :nodeType=>"text",
                        :data=>{}}]}]}]}]},
@@ -174,7 +174,7 @@ describe ContentfulConverter::Converter do
                   [{:nodeType=>"paragraph",
                     :data=>{},
                     :content=>
-                     [{:value=>"Content in a table data cell.",
+                     [{:value=>"Content in a table data cell second row.",
                        :marks=>[],
                        :nodeType=>"text",
                        :data=>{}}]}]}]}]}]}


### PR DESCRIPTION
Appends `tr`s to the `table` element so that the order of rows is not inverted during conversion.