### PR TITLE
Feat/empty table cells

### DIFF
--- a/lib/contentful_converter/nodes/tables/table.rb
+++ b/lib/contentful_converter/nodes/tables/table.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 module ContentfulConverter
   module Nodes
     module Tables

--- a/lib/contentful_converter/nodes/tables/table.rb
+++ b/lib/contentful_converter/nodes/tables/table.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'contentful_converter/nodes/base'
 
 module ContentfulConverter
   module Nodes

--- a/lib/contentful_converter/nodes/tables/table_cell_base.rb
+++ b/lib/contentful_converter/nodes/tables/table_cell_base.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'contentful_converter/nodes/base'
+
+
+module ContentfulConverter
+  module Nodes
+    module Tables
+      class TableCellBase < ::ContentfulConverter::Nodes::Base
+
+        def to_h(params = {})
+          h = super
+          h[:content] = [empty_node] if params[:content].empty?
+          h
+        end
+
+        private
+
+        def empty_node
+          empty_node =  {
+            :nodeType => "paragraph",
+            :data => {},
+            :content => [{
+              :nodeType => "text",
+              :data => {},
+              :value => "",
+              :marks => []
+            }]
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/contentful_converter/nodes/tables/table_data.rb
+++ b/lib/contentful_converter/nodes/tables/table_data.rb
@@ -2,6 +2,7 @@
 
 require 'contentful_converter/nodes/base'
 
+
 module ContentfulConverter
   module Nodes
     module Tables
@@ -10,7 +11,26 @@ module ContentfulConverter
           false
         end
 
+        def to_h(params = {})
+          h = super
+          h[:content] = [empty_node] if params[:content].empty?
+          h
+        end
+
         private
+
+        def empty_node
+          empty_node =  {
+            :nodeType => "paragraph",
+            :data => {},
+            :content => [{
+              :nodeType => "text",
+              :data => {},
+              :value => "",
+              :marks => []
+            }]
+          }
+        end
 
         def type
           'table-cell'

--- a/lib/contentful_converter/nodes/tables/table_data.rb
+++ b/lib/contentful_converter/nodes/tables/table_data.rb
@@ -1,36 +1,16 @@
 # frozen_string_literal: true
 
-require 'contentful_converter/nodes/base'
-
+require_relative './table_cell_base'
 
 module ContentfulConverter
   module Nodes
     module Tables
-      class TableData < Base
+      class TableData < TableCellBase
         def needs_p_wrapping?
           false
         end
 
-        def to_h(params = {})
-          h = super
-          h[:content] = [empty_node] if params[:content].empty?
-          h
-        end
-
         private
-
-        def empty_node
-          empty_node =  {
-            :nodeType => "paragraph",
-            :data => {},
-            :content => [{
-              :nodeType => "text",
-              :data => {},
-              :value => "",
-              :marks => []
-            }]
-          }
-        end
 
         def type
           'table-cell'

--- a/lib/contentful_converter/nodes/tables/table_header.rb
+++ b/lib/contentful_converter/nodes/tables/table_header.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-
 require 'contentful_converter/nodes/base'
+
 
 module ContentfulConverter
   module Nodes
@@ -10,7 +10,27 @@ module ContentfulConverter
           false
         end
 
+        def to_h(params = {})
+          h = super
+          h[:content] = [empty_node] if params[:content].empty?
+          h
+        end
+
         private
+
+
+        def empty_node
+          empty_node =  {
+            :nodeType => "paragraph",
+            :data => {},
+            :content => [{
+              :nodeType => "text",
+              :data => {},
+              :value => "",
+              :marks => []
+            }]
+          }
+        end
 
         def type
           'table-header-cell'

--- a/lib/contentful_converter/nodes/tables/table_header.rb
+++ b/lib/contentful_converter/nodes/tables/table_header.rb
@@ -1,36 +1,15 @@
 # frozen_string_literal: true
-require 'contentful_converter/nodes/base'
-
+require_relative './table_cell_base'
 
 module ContentfulConverter
   module Nodes
     module Tables
-      class TableHeader < Base
+      class TableHeader < TableCellBase
         def needs_p_wrapping?
           false
         end
 
-        def to_h(params = {})
-          h = super
-          h[:content] = [empty_node] if params[:content].empty?
-          h
-        end
-
         private
-
-
-        def empty_node
-          empty_node =  {
-            :nodeType => "paragraph",
-            :data => {},
-            :content => [{
-              :nodeType => "text",
-              :data => {},
-              :value => "",
-              :marks => []
-            }]
-          }
-        end
 
         def type
           'table-header-cell'

--- a/lib/contentful_converter/nodes/tables/table_row.rb
+++ b/lib/contentful_converter/nodes/tables/table_row.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'contentful_converter/nodes/base'
-
 module ContentfulConverter
   module Nodes
     module Tables

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/spec/features/tables_spec.rb
+++ b/spec/features/tables_spec.rb
@@ -15,10 +15,8 @@ describe ContentfulConverter::Converter do
           data: {},
           content: [{
             content: [
-              {
-                content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' },
-                          { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Rent' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'a) Fixed by landlord with 4 weeks notice to tenant.' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'b) Landlord must consult with those affected and take account of view expressed.' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Pre 1989 secure tenants of housing associations have a right to have their rent assessed by the rent officer every 3 years.' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Statutory assured tenants have the right to apply to the First-tier Tribunal for Scotland (Housing and Property Chamber).' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-row'
-              }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Right to buy ended on 1 August 2016' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'Changes to the original scheme to:' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'a) discount' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'b) the eligibility period' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'c) rent to loan scheme.' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Tenant kept their right to buy under conditions from the original scheme until they moved to another property.' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Tenant kept their right to buy under conditions from the original scheme until they moved to another property.' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-row' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Which rights' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'New Scottish secure tenant (SST)' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Was secure tenant now SST' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Was assured tenant now SST' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-row' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }
+              { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {},
+                nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Which rights' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'New Scottish secure tenant (SST)' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Was secure tenant now SST' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Was assured tenant now SST' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-header-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-row' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Rent' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'a) Fixed by landlord with 4 weeks notice to tenant.' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'b) Landlord must consult with those affected and take account of view expressed.' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Pre 1989 secure tenants of housing associations have a right to have their rent assessed by the rent officer every 3 years.' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Statutory assured tenants have the right to apply to the First-tier Tribunal for Scotland (Housing and Property Chamber).' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-row' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [{ type: 'bold' }], nodeType: 'text', value: 'Right to buy ended on 1 August 2016' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'Changes to the original scheme to:' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'a) discount' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'b) the eligibility period' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: 'c) rent to loan scheme.' }], data: {}, nodeType: 'paragraph' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Tenant kept their right to buy under conditions from the original scheme until they moved to another property.' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }, { content: [{ content: [{ data: {}, marks: [], nodeType: 'text', value: 'Tenant kept their right to buy under conditions from the original scheme until they moved to another property.' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-cell' }, { content: [{ data: {}, marks: [], nodeType: 'text', value: '\\n' }], data: {}, nodeType: 'paragraph' }], data: {}, nodeType: 'table-row' }
             ], data: {}, nodeType: 'table'
           }]
 
@@ -135,49 +133,40 @@ describe ContentfulConverter::Converter do
       end
     end
 
-
     context 'when there are two tables' do
-      let(:html) { '<table><tbody><tr><td><p>Content in a table data cell first row.</p></td></tr></tbody></table><p>Another table:</p><table><tbody><tr><td><p>Content in a table data cell second row.</p></td></tr></tbody></table>' }
+      let(:html) do
+        '<table><tbody><tr><td><p>Content in a table data cell first row.</p></td></tr></tbody></table><p>Another table:</p><table><tbody><tr><td><p>Content in a table data cell second row.</p></td></tr></tbody></table>'
+      end
       let(:expected_hash) do
-        {:nodeType=>"document",
-        :data=>{},
-        :content=>
-         [{:nodeType=>"table",
-           :data=>{},
-           :content=>
-            [{:nodeType=>"table-row",
-              :data=>{},
-              :content=>
-               [{:nodeType=>"table-cell",
-                 :data=>{},
-                 :content=>
-                  [{:nodeType=>"paragraph",
-                    :data=>{},
-                    :content=>
-                     [{:value=>"Content in a table data cell first row.",
-                       :marks=>[],
-                       :nodeType=>"text",
-                       :data=>{}}]}]}]}]},
-          {:nodeType=>"paragraph",
-           :data=>{},
-           :content=>
-            [{:value=>"Another table:", :marks=>[], :nodeType=>"text", :data=>{}}]},
-          {:nodeType=>"table",
-           :data=>{},
-           :content=>
-            [{:nodeType=>"table-row",
-              :data=>{},
-              :content=>
-               [{:nodeType=>"table-cell",
-                 :data=>{},
-                 :content=>
-                  [{:nodeType=>"paragraph",
-                    :data=>{},
-                    :content=>
-                     [{:value=>"Content in a table data cell second row.",
-                       :marks=>[],
-                       :nodeType=>"text",
-                       :data=>{}}]}]}]}]}]}
+        { nodeType: 'document',
+          data: {},
+          content: [{ nodeType: 'table',
+                      data: {},
+                      content: [{ nodeType: 'table-row',
+                                  data: {},
+                                  content: [{ nodeType: 'table-cell',
+                                              data: {},
+                                              content: [{ nodeType: 'paragraph',
+                                                          data: {},
+                                                          content: [{ value: 'Content in a table data cell first row.',
+                                                                      marks: [],
+                                                                      nodeType: 'text',
+                                                                      data: {} }] }] }] }] },
+                    { nodeType: 'paragraph',
+                      data: {},
+                      content: [{ value: 'Another table:', marks: [], nodeType: 'text', data: {} }] },
+                    { nodeType: 'table',
+                      data: {},
+                      content: [{ nodeType: 'table-row',
+                                  data: {},
+                                  content: [{ nodeType: 'table-cell',
+                                              data: {},
+                                              content: [{ nodeType: 'paragraph',
+                                                          data: {},
+                                                          content: [{ value: 'Content in a table data cell second row.',
+                                                                      marks: [],
+                                                                      nodeType: 'text',
+                                                                      data: {} }] }] }] }] }] }
       end
 
       it 'converts the table correctly' do
@@ -185,12 +174,15 @@ describe ContentfulConverter::Converter do
       end
     end
 
-    context "when there are empty table cells" do
+    context 'when there are empty table cells' do
       let(:html) { '<table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table>' }
+      let(:expected_hash) do
+        { nodeType: 'document', data: {},
+          content: [{ nodeType: 'table', data: {}, content: [{ nodeType: 'table-row', data: {}, content: [{ nodeType: 'table-header-cell', data: {}, content: [{ nodeType: 'paragraph', data: {}, content: [{ nodeType: 'text', data: {}, value: '', marks: [] }] }] }] }, { nodeType: 'table-row', data: {}, content: [{ nodeType: 'table-cell', data: {}, content: [{ nodeType: 'paragraph', data: {}, content: [{ nodeType: 'text', data: {}, value: '', marks: [] }] }] }] }] }] }
+      end
 
-      it "adds an non-breaking space" do
-        puts described_class.convert(html)
-        expect(described_class.convert(html)).to be_present
+      it 'adds an non-breaking space' do
+        expect(described_class.convert(html)).to eq expected_hash
       end
     end
   end

--- a/spec/features/tables_spec.rb
+++ b/spec/features/tables_spec.rb
@@ -184,5 +184,14 @@ describe ContentfulConverter::Converter do
         expect(described_class.convert(html)).to eq expected_hash
       end
     end
+
+    context "when there are empty table cells" do
+      let(:html) { '<table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table>' }
+
+      it "adds an non-breaking space" do
+        puts described_class.convert(html)
+        expect(described_class.convert(html)).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds support for empty table cells by adding an empty `p` into the hash representation of the table.